### PR TITLE
Make the main page more SEO friendly

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,8 @@
 # Site settings
-title: HackLand
+title: Hackland - A hakerspace in Auckland
 email: info@aucklandhackspace.nz
 url: http://hackland.nz/
-description: "A nest of tech, art, creativity and freedom"
+description: "A nest of tech, art, creativity and freedom.  Hackland is a makerspace/hakerspace/public workshop situated in Kingsland Auckland."
 
 # Color settings (hex-codes without the leading hash-tag)
 color:


### PR DESCRIPTION
A person came to Hackland yesterday, she said she had Googled "public workshop" in Auckland, but came up with nothing.  Let's hope this make Hackland more accessible to those who want to find it, but don't know the term "makerspace" or "hakerspace".