### PR TITLE
Update Join page as per Helena's request

### DIFF
--- a/join.md
+++ b/join.md
@@ -4,7 +4,7 @@ title: Join Hackland
 description: Join Hackland as a member to gain 24 hour access to the space and learn/make/create as much as your heart desires
 ---
 
-Members can use the space whenever they want, 24 hours every day of the week.
+Members can use the space whenever they want. Access is 24 hours (with noise restrictions from 8pm-8am).
 
 The hackspace is regularly open to the public whenever a member is in to open up, and weekly on Thursday from 6pm - this is the busiest time and the best for new people visiting.
 
@@ -19,12 +19,14 @@ Membership includes full access to everything 24/7<sup>1</sup> including:
 + All of the tea / coffee
 + We have recycling, rubbish and compost bins to use, please dispose of things properly. These services are for everyone to use, so if you want to dispose of large quantities please consider taking them to the [refuse centre](https://www.aucklandcouncil.govt.nz/rubbish-recycling/Pages/transfer-stations.aspx)
 
-<sup>1</sup> No powertools/noisy things after 7pm
+<sup>1</sup> No powertools/noisy things after 8pm
 
 Please have a read [here](/about/) for more information around how Hackland operates day to day
 
-**We don't accept members for one-off time-critical project (eg: holiday van build)** - there are commercial workshops you can rent for this purpose elsewhere, eg: The Warren, Gribblehurst Community Shed.
+**We don't accept members for one-off time-critical project (eg: holiday van build)** - there are commercial workshops you can rent for this purpose elsewhere.
 
-<h2 style="margin-top:2em;text-align:center;"><a href="https://forms.gle/V1RVY4Y9wvpLkGRp7" class="button"> Join</a></h2>
+<h2>Joining</h2>
+
+To join, come to our Open Day every Thursday 6-8pm to get a tour of the space by one of our members! Can’t make Thursdays? Join our slack channel [here](https://join.slack.com/t/hakland/shared_invite/zt-jrrkrdoi-it~AwREvT_ExamWwextFGw) to ask our members directly when they are around to show you the ropes.
 
 


### PR DESCRIPTION
Quote below, I made a minor change to fix small typos.

> The "join" tab on our homepage is out of date. We don't actually use that form anymore! Can someone web-savy please delete that link button and replace the text as per my comment in thread? Maybe [@Andy Pea](https://hakland.slack.com/team/UDBL2HRNY)?

> Members can use the space whenever they want. Access is 24 hours (with noise restrictions from 8pm-8am)
The hackspace is regularly open to the public whenever a member is in to open up, and weekly on Thursday from 6pm - this is the busiest time and the best for new people visiting.
Membership costs $20 a week but please pay as much as you feel is fair so the space can survive.
Membership includes full access to everything 24/71 including:
UNLIMITED Fibre Internet
Access to all of the tools
A Storage Box for projects
A quiet place to work (sometimes quiet)
All of the tea / coffee
We have recycling, rubbish and compost bins to use, please dispose of things properly. These services are for everyone to use, so if you want to dispose of large quantities please consider taking them to the [refuse centre](https://www.aucklandcouncil.govt.nz/rubbish-recycling/Pages/transfer-stations.aspx)
1 No powertools/noisy things after 8pm
Please have a read [here](https://hackland.nz/about/) for more information around how Hackland operates day to day
We don’t accept members for one-off time-critical project (eg: holiday van build) - please try a are commercial workshops you can rent for this purpose elsewhere.
To join, come to our Open Day every Thursday 6-8pm to get a tour of the space by one of our members!
Can’t make Thursdays? Join our slack channel (https://join.slack.com/t/hakland/shared_invite/zt-jrrkrdoi-it~AwREvT_ExamWwextFGw) to ask our members directly when they are around to show you the ropes.